### PR TITLE
Save donator customizations in the API better

### DIFF
--- a/api/v1/db/UserManager.js
+++ b/api/v1/db/UserManager.js
@@ -3893,7 +3893,7 @@ class UserManager {
      * @returns {null|string} `null` if the customData is valid, and a string containing the error reason if the customData is invalid.
      */
     seeBlockedUserCustomization(customData) {
-        if (typeof customData === "object" || Array.isArray(customData)) return "DataNotObject";
+        if (typeof customData !== "object" || Array.isArray(customData)) return "DataNotObject";
         const allowedTypes = ["string", "number", "boolean", "object"]; // object is specified but we actually only allow Arrays
         const allowedArrayValueTypes = ["string", "number", "boolean"]; // since we allow arrays, we only allow some types in those arrays
 

--- a/api/v1/db/UserManager.js
+++ b/api/v1/db/UserManager.js
@@ -3879,7 +3879,7 @@ class UserManager {
     async getUserCustomization(username) {
         const result = await this.accountCustomization.findOne({ username: username });
 
-        return result.customData;
+        return result.customData || {};
     }
     async getUserCustomizationDisabled(username) {
         const result = await this.accountCustomization.findOne({ username: username });

--- a/api/v1/db/UserManager.js
+++ b/api/v1/db/UserManager.js
@@ -3889,11 +3889,11 @@ class UserManager {
 
     /**
      * User customization is arbitrary customization data, meant for donators to customize their profile.
-     * This function checks whether or not 
+     * This function checks whether or not the arbitrary data fits our requirements
      * @param {Object} customData Arbitrary keys and values
      * @returns {null|string} `null` if the customData is valid, and a string containing the error reason if the customData is invalid.
      */
-    seeBlockedUserCustomization(customData) {
+    verifyCustomData(customData) {
         if (typeof customData !== "object" || Array.isArray(customData)) return "DataNotObject";
         const allowedTypes = ["string", "number", "boolean", "object"]; // object is specified but we actually only allow Arrays
         const allowedArrayValueTypes = ["string", "number", "boolean"]; // since we allow arrays, we only allow some types in those arrays
@@ -3927,7 +3927,7 @@ class UserManager {
 
     /**
      * Sets arbitrary customization data, meant for donators to customize their profile.
-     * Any endpoint that exposes this functionality to regular users should also make sure `seeBlockedUserCustomization` does not give an error reason.
+     * Any endpoint that exposes this functionality to regular users should also make sure `verifyCustomData` does not give an error reason.
      * @param {string} username The user to set the customization data for
      * @param {Object} customData Arbitrary keys and values
      */

--- a/api/v1/db/UserManager.js
+++ b/api/v1/db/UserManager.js
@@ -3878,11 +3878,12 @@ class UserManager {
      */
     async getUserCustomization(username) {
         const result = await this.accountCustomization.findOne({ username: username });
-
+        if (!result) return {};
         return result.customData || {};
     }
     async getUserCustomizationDisabled(username) {
         const result = await this.accountCustomization.findOne({ username: username });
+        if (!result) return false;
         return result.disabled === true;
     }
 
@@ -3931,10 +3932,10 @@ class UserManager {
      * @param {Object} customData Arbitrary keys and values
      */
     async setUserCustomization(username, customData) {
-        await this.accountCustomization.updateOne({ username: username }, { $set: { customData: customData } });
+        await this.accountCustomization.updateOne({ username: username }, { $set: { customData: customData } }, { upsert: true });
     }
     async setUserCustomizationDisabled(username, disabled) {
-        await this.accountCustomization.updateOne({ username: username }, { $set: { disabled: disabled } });
+        await this.accountCustomization.updateOne({ username: username }, { $set: { disabled: disabled } }, { upsert: true });
     }
 
     async clearAllEmails() {

--- a/api/v1/db/UserManager.js
+++ b/api/v1/db/UserManager.js
@@ -3871,14 +3871,70 @@ class UserManager {
         return !!result ? true : false;
     }
 
+    /**
+     * Gets arbitrary customization data, meant for donators to customize their profile.
+     * @param {string} username The user with the customization data
+     * @returns {Object} Arbitrary keys and values
+     */
     async getUserCustomization(username) {
         const result = await this.accountCustomization.findOne({ username: username });
 
-        return result.text;
+        return result.customData;
+    }
+    async getUserCustomizationDisabled(username) {
+        const result = await this.accountCustomization.findOne({ username: username });
+        return result.disabled === true;
     }
 
-    async setUserCustomization(username, text) {
-        await this.accountCustomization.updateOne({ username: username }, { $set: { text: text } });
+    /**
+     * User customization is arbitrary customization data, meant for donators to customize their profile.
+     * This function checks whether or not 
+     * @param {Object} customData Arbitrary keys and values
+     * @returns {null|string} `null` if the customData is valid, and a string containing the error reason if the customData is invalid.
+     */
+    seeBlockedUserCustomization(customData) {
+        if (typeof customData === "object" || Array.isArray(customData)) return "DataNotObject";
+        const allowedTypes = ["string", "number", "boolean", "object"]; // object is specified but we actually only allow Arrays
+        const allowedArrayValueTypes = ["string", "number", "boolean"]; // since we allow arrays, we only allow some types in those arrays
+
+        // block too much stuff and also reserve stuff incase we have some weird reason to use it later
+        const keys = Object.keys(customData);
+        const values = Object.values(customData);
+        if (keys.length > 64) return "TooManyKeys";
+        if (keys.some(key => key.startsWith("_") || key.length > 64)) return "InvalidKeyName";
+
+        // block values
+        const areValuesInvalid = values.some(value => (!allowedTypes.includes(typeof value)) // type isnt allowed
+            || (typeof value === "string" && value.length > 256) // string > 256 chars not allowed
+            || (typeof value === "object" && !Array.isArray(value))); // if we are an object, block if we arent an array
+        if (areValuesInvalid) return "InvalidValueFound";
+
+        // block arrays specified
+        const arrayValues = values.filter(value => typeof value === "object" && Array.isArray(value));
+        if (arrayValues.length > 4) return "TooManyArrays";
+
+        // each array specified adds its amount of items to a total, and that total cannot exceed a certain amount
+        const mixedArrays = arrayValues.flat(); // makes each array into 1 array
+        if (mixedArrays.length > 64) return "TooManyValuesTotalWithinAllArrays";
+
+        const areArrayValuesInvalid = mixedArrays.some(value => (!allowedArrayValueTypes.includes(typeof value)) // type isnt allowed
+            || (typeof value === "string" && value.length > 64)); // string > 64 chars not allowed
+        if (areArrayValuesInvalid) return "InvalidValueWithinArrayFound";
+
+        return null;
+    }
+
+    /**
+     * Sets arbitrary customization data, meant for donators to customize their profile.
+     * Any endpoint that exposes this functionality to regular users should also make sure `seeBlockedUserCustomization` does not give an error reason.
+     * @param {string} username The user to set the customization data for
+     * @param {Object} customData Arbitrary keys and values
+     */
+    async setUserCustomization(username, customData) {
+        await this.accountCustomization.updateOne({ username: username }, { $set: { customData: customData } });
+    }
+    async setUserCustomizationDisabled(username, disabled) {
+        await this.accountCustomization.updateOne({ username: username }, { $set: { disabled: disabled } });
     }
 
     async clearAllEmails() {

--- a/api/v1/routes/meta/api.js
+++ b/api/v1/routes/meta/api.js
@@ -10,7 +10,7 @@ module.exports = function(app, utils) {
         metadata.version.git = utils.env.__GIT ? utils.env.__GIT : "Unknown";
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json(metadata);
     });
 }

--- a/api/v1/routes/misc/getLastPolicyRead.js
+++ b/api/v1/routes/misc/getLastPolicyRead.js
@@ -26,7 +26,7 @@ module.exports = (app, utils) => {
         const lastPolicyRead = await utils.UserManager.getLastPolicyRead(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json(lastPolicyRead); // its already an object
     });
 }

--- a/api/v1/routes/misc/getLastPolicyUpdate.js
+++ b/api/v1/routes/misc/getLastPolicyUpdate.js
@@ -15,7 +15,7 @@ module.exports = (app, utils) => {
         const lastPolicyUpdate = await utils.UserManager.getLastPolicyUpdate();
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json(lastPolicyUpdate); // its already an object
     });
 }

--- a/api/v1/routes/misc/getProfanityList.js
+++ b/api/v1/routes/misc/getProfanityList.js
@@ -29,7 +29,7 @@ module.exports = (app, utils) => {
         const illegalWords = await utils.UserManager.getIllegalWords();
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json(illegalWords);
     });
 }

--- a/api/v1/routes/misc/getStats.js
+++ b/api/v1/routes/misc/getStats.js
@@ -15,7 +15,7 @@ module.exports = (app, utils) => {
         const stats = await utils.UserManager.getStats();
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json(stats);
     });
 }

--- a/api/v1/routes/misc/markGuidelinesAsRead.js
+++ b/api/v1/routes/misc/markGuidelinesAsRead.js
@@ -26,7 +26,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.markGuidelinesAsRead(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ success: true });
     });
 }

--- a/api/v1/routes/misc/markPrivacyPolicyAsRead.js
+++ b/api/v1/routes/misc/markPrivacyPolicyAsRead.js
@@ -26,7 +26,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.markPrivacyPolicyAsRead(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ success: true });
     });
 }

--- a/api/v1/routes/misc/markTOSAsRead.js
+++ b/api/v1/routes/misc/markTOSAsRead.js
@@ -26,7 +26,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.markTOSAsRead(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ success: true });
     });
 }

--- a/api/v1/routes/misc/setLastPolicyUpdate.js
+++ b/api/v1/routes/misc/setLastPolicyUpdate.js
@@ -75,7 +75,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ success: true });
     });
 }

--- a/api/v1/routes/misc/setProfanityList.js
+++ b/api/v1/routes/misc/setProfanityList.js
@@ -103,7 +103,7 @@ module.exports = (app, utils) => {
         );
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/projects/canUploadProjects.js
+++ b/api/v1/routes/projects/canUploadProjects.js
@@ -14,6 +14,8 @@ module.exports = (app, utils) => {
     app.get('/api/v1/projects/canuploadprojects', async (req, res) => {
         const canUpload = await utils.UserManager.getRuntimeConfigItem("uploadingEnabled");
 
+        res.status(200);
+        res.header("Content-Type", "application/json");
         return res.send({ canUpload });
     });
 }

--- a/api/v1/routes/projects/canViewProjects.js
+++ b/api/v1/routes/projects/canViewProjects.js
@@ -14,6 +14,8 @@ module.exports = (app, utils) => {
     app.get('/api/v1/projects/canviewprojects', async (req, res) => {
         const viewing = await utils.UserManager.getRuntimeConfigItem("viewingEnabled");
 
+        res.status(200);
+        res.header("Content-Type", "application/json");
         return res.send({ viewing: viewing });
     });
 }

--- a/api/v1/routes/projects/getProject.js
+++ b/api/v1/routes/projects/getProject.js
@@ -70,8 +70,12 @@ module.exports = (app, utils) => {
                 case "thumbnail":
                     const thumbnail = fs.readFileSync(path.join(utils.homeDir, "icon.png"));
                     
+                    res.status(200);
+                    res.header("Content-Type", "image/png");
                     return res.send(thumbnail);
                 case "metadata":
+                    res.status(200);
+                    res.header("Content-Type", "application/json");
                     return res.send({ author: "No Author", title: "No Title", public: false }); // TODO: eventually make this return all of the placeholder data, instead of just like 3 things
                 default:
                     return utils.error(res, 400, "Invalid requestType");
@@ -102,6 +106,8 @@ module.exports = (app, utils) => {
             case "protobuf":
                 const project = await utils.UserManager.getProjectFile(projectID);
 
+                res.status(200);
+                res.header("Content-Type", "application/json");
                 return res.send(project);
             case "assets":
                 const assets = await utils.UserManager.getProjectAssets(projectID);

--- a/api/v1/routes/projects/getProjects.js
+++ b/api/v1/routes/projects/getProjects.js
@@ -32,7 +32,7 @@ module.exports = (app, utils) => {
         }
 
         res.status(200);
-        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Content-Type', "application/json");
         return res.send(projects);
     }
 )}

--- a/api/v1/routes/projects/modActions/reject/dispute.js
+++ b/api/v1/routes/projects/modActions/reject/dispute.js
@@ -45,7 +45,7 @@ module.exports = (app, utils) => {
         utils.logs.disputeLog(username, messageID, message.message, dispute, message.projectID);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/projects/search/getMyProjects.js
+++ b/api/v1/routes/projects/search/getMyProjects.js
@@ -34,7 +34,7 @@ module.exports = (app, utils) => {
         const projects = await utils.UserManager.getProjectsByAuthor(authorID, page, Number(utils.env.PageSize), true, true);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         return res.send(projects);
     });
 }

--- a/api/v1/routes/projects/search/getRandom.js
+++ b/api/v1/routes/projects/search/getRandom.js
@@ -15,7 +15,7 @@ module.exports = (app, utils) => {
         const project = await utils.UserManager.getRandomProjects(1);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         return res.send(project.length > 0 ? project[0] : {});
     });
 }

--- a/api/v1/routes/users/blockUser.js
+++ b/api/v1/routes/users/blockUser.js
@@ -39,7 +39,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.blockUser(user_id, target_id, active);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/users/getMyFeed.js
+++ b/api/v1/routes/users/getMyFeed.js
@@ -57,7 +57,7 @@ module.exports = (app, utils) => {
         }
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ feed: final });
     });
 }

--- a/api/v1/routes/users/hasBlocked.js
+++ b/api/v1/routes/users/hasBlocked.js
@@ -34,7 +34,7 @@ module.exports = (app, utils) => {
         const has_blocked = await utils.UserManager.hasBlocked(user_id, target_id);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ has_blocked });
     });
 }

--- a/api/v1/routes/users/login/changePassword.js
+++ b/api/v1/routes/users/login/changePassword.js
@@ -61,7 +61,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.addIP(username, req.realIP);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "token": newToken });
     });
 }

--- a/api/v1/routes/users/login/createAccount.js
+++ b/api/v1/routes/users/login/createAccount.js
@@ -67,7 +67,7 @@ module.exports = (app, utils) => {
 
         /*
         res.status(500);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "disabled": true });
         return;
         */
@@ -167,7 +167,7 @@ module.exports = (app, utils) => {
         await utils.logs.sendCreationLog(username, id, "", "account");
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "token": token });
     });
 }

--- a/api/v1/routes/users/login/filloutSafetyDetails.js
+++ b/api/v1/routes/users/login/filloutSafetyDetails.js
@@ -83,7 +83,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setUserBirthdayAndOrCountry(username, parsedBirthday, countryCode);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/login/logout.js
+++ b/api/v1/routes/users/login/logout.js
@@ -31,7 +31,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.logout(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/login/passwordLogin.js
+++ b/api/v1/routes/users/login/passwordLogin.js
@@ -73,7 +73,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.addIP(username, req.realIP);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "token": token });
     });
 }

--- a/api/v1/routes/users/login/resetpassword/reset.js
+++ b/api/v1/routes/users/login/resetpassword/reset.js
@@ -45,7 +45,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.changePassword(username, password);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     })
 }

--- a/api/v1/routes/users/login/resetpassword/sendEmail.js
+++ b/api/v1/routes/users/login/resetpassword/sendEmail.js
@@ -127,7 +127,7 @@ module.exports = (app, utils) => {
         }
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/login/resetpassword/sendVerificationEmail.js
+++ b/api/v1/routes/users/login/resetpassword/sendVerificationEmail.js
@@ -106,7 +106,7 @@ module.exports = (app, utils) => {
         }
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/login/tokenLogin.js
+++ b/api/v1/routes/users/login/tokenLogin.js
@@ -29,7 +29,7 @@ module.exports = (app, utils) => {
         const username = login.username;
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true});
     });
 }

--- a/api/v1/routes/users/meta/changeUsername.js
+++ b/api/v1/routes/users/meta/changeUsername.js
@@ -104,7 +104,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.changeUsername(username, newUsername, String(packet.newUsername));
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     })
 }

--- a/api/v1/routes/users/meta/customization/getCustomization.js
+++ b/api/v1/routes/users/meta/customization/getCustomization.js
@@ -1,0 +1,48 @@
+const UserManager = require("../../../../db/UserManager");
+
+/**
+ * @typedef {Object} Utils
+ * @property {UserManager} UserManager
+ */
+
+/**
+ * 
+ * @param {any} app Express app
+ * @param {Utils} utils Utils
+ */
+module.exports = (app, utils) => {
+    app.post("/api/v1/users/customization/getCustomization", utils.cors(), async (req, res) => {
+        const packet = req.body;
+
+        const target = String(packet.target).toLowerCase();
+
+        if (!target) {
+            utils.error(res, 400, "Missing target");
+            return;
+        }
+
+        const exists = await utils.UserManager.existsByUsername(target, false);
+        if (!exists) {
+            utils.error(res, 404, "User does not exist");
+            return;
+        }
+
+        const badges = await utils.UserManager.getBadges(target);
+        if (!badges.includes("donator")) {
+            utils.error(res, 400, "NotDonator");
+            return;
+        }
+
+        // if disabled just return default {}
+        if (utils.UserManager.getUserCustomizationDisabled(target)) {
+            res.status(200);
+            res.header("Content-Type", 'application/json');
+            return res.send({});
+        }
+        
+        const customization = utils.UserManager.getUserCustomization(target);
+        res.status(200);
+        res.header("Content-Type", 'application/json');
+        res.send(customization);
+    })
+}

--- a/api/v1/routes/users/meta/customization/getCustomization.js
+++ b/api/v1/routes/users/meta/customization/getCustomization.js
@@ -36,13 +36,13 @@ module.exports = (app, utils) => {
         // if disabled just return default {}
         if (await utils.UserManager.getUserCustomizationDisabled(target)) {
             res.status(200);
-            res.header("Content-Type", 'application/json');
+            res.header("Content-Type", "application/json");
             return res.send({ customization: {} });
         }
 
         const customization = await utils.UserManager.getUserCustomization(target);
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ customization });
     })
 }

--- a/api/v1/routes/users/meta/customization/getCustomization.js
+++ b/api/v1/routes/users/meta/customization/getCustomization.js
@@ -34,13 +34,13 @@ module.exports = (app, utils) => {
         }
 
         // if disabled just return default {}
-        if (utils.UserManager.getUserCustomizationDisabled(target)) {
+        if (await utils.UserManager.getUserCustomizationDisabled(target)) {
             res.status(200);
             res.header("Content-Type", 'application/json');
-            return res.send({});
+            return res.send({ customization: {} });
         }
 
-        const customization = utils.UserManager.getUserCustomization(target);
+        const customization = await utils.UserManager.getUserCustomization(target);
         res.status(200);
         res.header("Content-Type", 'application/json');
         res.send({ customization });

--- a/api/v1/routes/users/meta/customization/getCustomization.js
+++ b/api/v1/routes/users/meta/customization/getCustomization.js
@@ -11,8 +11,8 @@ const UserManager = require("../../../../db/UserManager");
  * @param {Utils} utils Utils
  */
 module.exports = (app, utils) => {
-    app.post("/api/v1/users/customization/getCustomization", utils.cors(), async (req, res) => {
-        const packet = req.body;
+    app.get("/api/v1/users/customization/getCustomization", utils.cors(), async (req, res) => {
+        const packet = req.query;
 
         const target = String(packet.target).toLowerCase();
 
@@ -39,7 +39,7 @@ module.exports = (app, utils) => {
             res.header("Content-Type", 'application/json');
             return res.send({});
         }
-        
+
         const customization = utils.UserManager.getUserCustomization(target);
         res.status(200);
         res.header("Content-Type", 'application/json');

--- a/api/v1/routes/users/meta/customization/getCustomization.js
+++ b/api/v1/routes/users/meta/customization/getCustomization.js
@@ -43,6 +43,6 @@ module.exports = (app, utils) => {
         const customization = utils.UserManager.getUserCustomization(target);
         res.status(200);
         res.header("Content-Type", 'application/json');
-        res.send(customization);
+        res.send({ customization });
     })
 }

--- a/api/v1/routes/users/meta/customization/setCustomization.js
+++ b/api/v1/routes/users/meta/customization/setCustomization.js
@@ -52,7 +52,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setUserCustomization(target || username, customization);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/meta/customization/setCustomization.js
+++ b/api/v1/routes/users/meta/customization/setCustomization.js
@@ -17,7 +17,7 @@ module.exports = (app, utils) => {
         const token = packet.token;
         const customization = packet.customization;
 
-        if (!token || typeof(customization) !== "string") {
+        if (!token || !customization || typeof(customization) !== "object") {
             utils.error(res, 400, "Missing token or customization");
             return;
         }
@@ -35,7 +35,13 @@ module.exports = (app, utils) => {
             utils.error(res, 403, "MissingPermission");
             return;
         }
+        if (utils.UserManager.getUserCustomizationDisabled(username)) {
+            utils.error(res, 403, "FeatureDisabledForThisAccount");
+            return;
+        }
 
+        const errorReason = utils.UserManager.seeBlockedUserCustomization(customization);
+        if (errorReason) return utils.error(res, 400, errorReason);
         await utils.UserManager.setUserCustomization(username, customization);
 
         res.status(200);

--- a/api/v1/routes/users/meta/customization/setCustomization.js
+++ b/api/v1/routes/users/meta/customization/setCustomization.js
@@ -16,7 +16,7 @@ module.exports = (app, utils) => {
 
         const token = packet.token;
         const customization = packet.customization;
-
+        
         if (!token || !customization || typeof(customization) !== "object") {
             utils.error(res, 400, "Missing token or customization");
             return;

--- a/api/v1/routes/users/meta/customization/setCustomization.js
+++ b/api/v1/routes/users/meta/customization/setCustomization.js
@@ -47,7 +47,7 @@ module.exports = (app, utils) => {
             }
         }
 
-        const errorReason = utils.UserManager.seeBlockedUserCustomization(customization);
+        const errorReason = utils.UserManager.verifyCustomData(customization);
         if (errorReason) return utils.error(res, 400, errorReason);
         await utils.UserManager.setUserCustomization(target || username, customization);
 

--- a/api/v1/routes/users/meta/customization/setCustomization.js
+++ b/api/v1/routes/users/meta/customization/setCustomization.js
@@ -30,7 +30,7 @@ module.exports = (app, utils) => {
         const username = login.username;
 
         // you can change other people's customization if you are a mod
-        const target = String(packet.target).toLowerCase();
+        const target = packet.target ? String(packet.target).toLowerCase() : null;
         if (target && !utils.UserManager.isModeratorOrAdmin(username)) {
             return utils.error(res, 401, "Invalid credentials");
         }
@@ -41,7 +41,7 @@ module.exports = (app, utils) => {
                 utils.error(res, 403, "MissingPermission");
                 return;
             }
-            if (utils.UserManager.getUserCustomizationDisabled(username)) {
+            if (await utils.UserManager.getUserCustomizationDisabled(username)) {
                 utils.error(res, 403, "FeatureDisabledForThisAccount");
                 return;
             }

--- a/api/v1/routes/users/meta/customization/setCustomizationDisabled.js
+++ b/api/v1/routes/users/meta/customization/setCustomizationDisabled.js
@@ -1,0 +1,48 @@
+const UserManager = require("../../../../db/UserManager");
+
+/**
+ * @typedef {Object} Utils
+ * @property {UserManager} UserManager
+ */
+
+/**
+ * 
+ * @param {any} app Express app
+ * @param {Utils} utils Utils
+ */
+module.exports = (app, utils) => {
+    app.post("/api/v1/users/customization/setCustomizationDisabled", utils.cors(), async (req, res) => {
+        const packet = req.body;
+
+        const token = packet.token;
+
+        const target = String(packet.target).toLowerCase();
+        const isEnabled = packet.toggle;
+
+        if (!token || typeof isEnabled !== "boolean") {
+            return utils.error(res, 400, "Missing token, or toggle");
+        }
+
+        const login = await utils.UserManager.loginWithToken(token);
+        if (!login.success) {
+            utils.error(res, 401, "Reauthenticate")
+            return;
+        }
+        const username = login.username;
+
+        if (!await utils.UserManager.isModeratorOrAdmin(username)) {
+            return utils.error(res, 401, "Invalid credentials");
+        }
+
+        await utils.UserManager.setUserCustomizationDisabled(target, !isEnabled);
+
+        utils.logs.sendAdminUserLog(username, target, "Admin has updated user's ability to customize their profile.", 0x8c03fc, [
+            {
+                name: "Is Enabled?",
+                value: String(isEnabled)
+            }
+        ]);
+
+        return res.send({ success: true });
+    });
+}

--- a/api/v1/routes/users/meta/customization/setCustomizationDisabled.js
+++ b/api/v1/routes/users/meta/customization/setCustomizationDisabled.js
@@ -43,6 +43,8 @@ module.exports = (app, utils) => {
             }
         ]);
 
+        res.status(200);
+        res.header("Content-Type", "application/json");
         return res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/meta/following/follow.js
+++ b/api/v1/routes/users/meta/following/follow.js
@@ -67,7 +67,7 @@ module.exports = (app, utils) => {
         }
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/meta/following/getFollowerCount.js
+++ b/api/v1/routes/users/meta/following/getFollowerCount.js
@@ -24,7 +24,7 @@ module.exports = (app, utils) => {
         const count = await utils.UserManager.getFollowerCount(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ count: count });
     });
 }

--- a/api/v1/routes/users/meta/following/getFollowers.js
+++ b/api/v1/routes/users/meta/following/getFollowers.js
@@ -30,7 +30,7 @@ module.exports = (app, utils) => {
         const followers = await utils.UserManager.getFollowers(username, page, Number(utils.env.PageSize));
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send(followers);
     });
 }

--- a/api/v1/routes/users/meta/following/isFollowing.js
+++ b/api/v1/routes/users/meta/following/isFollowing.js
@@ -38,7 +38,7 @@ module.exports = (app, utils) => {
         const isFollowing = await utils.UserManager.isFollowing(usernameID, targetID);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ following: isFollowing });
     });
 }

--- a/api/v1/routes/users/meta/getBadges.js
+++ b/api/v1/routes/users/meta/getBadges.js
@@ -24,7 +24,7 @@ module.exports = (app, utils) => {
         const badges = await utils.UserManager.getBadges(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ badges: badges });
     });
 }

--- a/api/v1/routes/users/meta/getProjectCountOfUser.js
+++ b/api/v1/routes/users/meta/getProjectCountOfUser.js
@@ -32,7 +32,7 @@ module.exports = (app, utils) => {
         const count = await utils.UserManager.getProjectCountOfUser(id);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ count });
     })
 }

--- a/api/v1/routes/users/meta/isBanned.js
+++ b/api/v1/routes/users/meta/isBanned.js
@@ -24,7 +24,7 @@ module.exports = (app, utils) => {
         const isBanned = await utils.UserManager.isBanned(username);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ isBanned: isBanned });
     });
 }

--- a/api/v1/routes/users/meta/setBio.js
+++ b/api/v1/routes/users/meta/setBio.js
@@ -79,7 +79,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setBio(username, bio);
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/api/v1/routes/users/meta/setMyFeaturedProject.js
+++ b/api/v1/routes/users/meta/setMyFeaturedProject.js
@@ -44,7 +44,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setFeaturedProjectTitle(username, title);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/api/v1/routes/users/meta/setPFP.js
+++ b/api/v1/routes/users/meta/setPFP.js
@@ -58,7 +58,7 @@ module.exports = (app, utils) => {
             await utils.UserManager.setProfilePicture(username, resized_picture);
 
             res.status(200);
-            res.header("Content-Type", 'application/json');
+            res.header("Content-Type", "application/json");
             res.json({ "success": true });
         });
     });

--- a/api/v1/routes/users/mod/admin_only/assignPossition.js
+++ b/api/v1/routes/users/mod/admin_only/assignPossition.js
@@ -60,7 +60,7 @@ module.exports = (app, utils) => {
         utils.logs.sendAdminUserLog(username, target, "Admin or mod has updated user's permissions.", 0x7f3ddc, fields);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/banIP.js
+++ b/api/v1/routes/users/mod/admin_only/banIP.js
@@ -75,7 +75,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/banUserIP.js
+++ b/api/v1/routes/users/mod/admin_only/banUserIP.js
@@ -69,7 +69,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/changeProjectID.js
+++ b/api/v1/routes/users/mod/admin_only/changeProjectID.js
@@ -72,7 +72,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/getAllAccountsWithIP.js
+++ b/api/v1/routes/users/mod/admin_only/getAllAccountsWithIP.js
@@ -32,7 +32,7 @@ module.exports = (app, utils) => {
         const users = await utils.UserManager.getAllAccountsWithIP(target);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ users });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/getAllIPs.js
+++ b/api/v1/routes/users/mod/admin_only/getAllIPs.js
@@ -36,7 +36,7 @@ module.exports = (app, utils) => {
         const ips = await utils.UserManager.getIPs(target);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ ips });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/massBan.js
+++ b/api/v1/routes/users/mod/admin_only/massBan.js
@@ -69,7 +69,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true, count });
     });
 }

--- a/api/v1/routes/users/mod/admin_only/verifyFollowers.js
+++ b/api/v1/routes/users/mod/admin_only/verifyFollowers.js
@@ -38,7 +38,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.verifyFollowers(target);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/mod/ban.js
+++ b/api/v1/routes/users/mod/ban.js
@@ -114,7 +114,7 @@ module.exports = (app, utils) => {
         );
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ success: true });
     });
 }

--- a/api/v1/routes/users/mod/getAlts.js
+++ b/api/v1/routes/users/mod/getAlts.js
@@ -46,7 +46,7 @@ module.exports = (app, utils) => {
         const usernames = await utils.UserManager.idListToUsernames(alts);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ alts: usernames });
     });
 }

--- a/api/v1/routes/users/mod/setBioAdmin.js
+++ b/api/v1/routes/users/mod/setBioAdmin.js
@@ -48,7 +48,7 @@ module.exports = (app, utils) => {
         utils.logs.sendBioUpdateLog(username, target, oldBio, bio);
         
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/api/v1/routes/users/mod/setFeaturedProjectAdmin.js
+++ b/api/v1/routes/users/mod/setFeaturedProjectAdmin.js
@@ -61,7 +61,7 @@ module.exports = (app, utils) => {
         ]);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/api/v1/routes/users/mod/setPFP.js
+++ b/api/v1/routes/users/mod/setPFP.js
@@ -69,7 +69,7 @@ module.exports = (app, utils) => {
             utils.logs.sendAdminUserLog(username, target, "Admin or mod has updated user's profile picture.", 0xf4a220);
 
             res.status(200);
-            res.header("Content-Type", 'application/json');
+            res.header("Content-Type", "application/json");
             res.json({ "success": true });
         });
     });

--- a/api/v1/routes/users/mod/setUsername.js
+++ b/api/v1/routes/users/mod/setUsername.js
@@ -50,7 +50,7 @@ module.exports = (app, utils) => {
         ]);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/users/oauth/removeMethod/removeOAuthMethod.js
+++ b/api/v1/routes/users/oauth/removeMethod/removeOAuthMethod.js
@@ -40,7 +40,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.removeOAuthMethod(username, method);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/api/v1/routes/users/requestRankUp.js
+++ b/api/v1/routes/users/requestRankUp.js
@@ -48,7 +48,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setRank(username, 1); // 1 is normal penguin
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.json({ "success": true });
     });
 }

--- a/api/v1/routes/users/setEmail.js
+++ b/api/v1/routes/users/setEmail.js
@@ -49,7 +49,7 @@ module.exports = (app, utils) => {
         await utils.UserManager.setEmail(username, email);
 
         res.status(200);
-        res.header("Content-Type", 'application/json');
+        res.header("Content-Type", "application/json");
         res.send({ "success": true });
     });
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function escapeXML(unsafe) {
 
 function error(res, code, error) {
     res.status(code);
-    res.header("Content-Type", 'application/json');
+    res.header("Content-Type", "application/json");
     res.json({ "error": error });
 }
 


### PR DESCRIPTION
so instead of having to serialize the customizations into one big string with all the data and deserialize it on the frontend
this just saves a limited object to your account which can just be read normally like other info

from a small test this seems to work well